### PR TITLE
Implementar RF-PolitRecebMsg

### DIFF
--- a/src/main/java/br/ufg/inf/enums/PoliticaRecebimentoMensagens.java
+++ b/src/main/java/br/ufg/inf/enums/PoliticaRecebimentoMensagens.java
@@ -1,19 +1,5 @@
 package br.ufg.inf.enums;
 
 public enum PoliticaRecebimentoMensagens {
-    CADA_EVENTO(1), DIARIA(2), SEMANAL(3), MENSAL(4), NAO_RECEBE(5);
-
-    private int valor;
-
-    private PoliticaRecebimentoMensagens(int valor) {
-        this.valor = valor;
-    }
-
-    public int getValor() {
-        return valor;
-    }
-
-    public void mudarPolitica(int valor) {
-        this.valor = valor;
-    }
+    CADA_EVENTO, DIARIA, SEMANAL, MENSAL, NAO_RECEBE;
 }

--- a/src/main/java/br/ufg/inf/modelo/Usuario.java
+++ b/src/main/java/br/ufg/inf/modelo/Usuario.java
@@ -13,7 +13,7 @@ public class Usuario {
     private String nome;
     private String cpf;
     private BitSet foto = new BitSet();
-    private PoliticaRecebimentoMensagens tipoDivulgacao;
+    private PoliticaRecebimentoMensagens tipoDivulgacao = PoliticaRecebimentoMensagens.CADA_EVENTO;
     private Date ts_cadastramento;
     private Date ts_ult_update;
     private Date ts_exclusao;

--- a/src/test/java/br/ufg/inf/servico/PoliticaRecebimentoMensagemTest.java
+++ b/src/test/java/br/ufg/inf/servico/PoliticaRecebimentoMensagemTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class PoliticaRecebimentoMensagemTest {
 
@@ -64,10 +65,15 @@ public class PoliticaRecebimentoMensagemTest {
 
 	@Test
 	public void testaPoliticaPadrao(){
-		politica = PoliticaRecebimentoMensagens.CADA_EVENTO;
-		usuario.setTipoDivulgacao(politica);
 		assertEquals("CADA_EVENTO", usuario.getTipoDivulgacao().toString());
 	}
 
+    @Test
+    public void testaAlteracaoDaPoliticaDeMensagem(){
+        usuario.setTipoDivulgacao(PoliticaRecebimentoMensagens.CADA_EVENTO);
+        usuario.setTipoDivulgacao(PoliticaRecebimentoMensagens.MENSAL);
 
+        assertNotEquals("CADA_EVENTO", usuario.getTipoDivulgacao().toString());
+        assertEquals("MENSAL", usuario.getTipoDivulgacao().toString());
+    }
 }


### PR DESCRIPTION
Refatoração da enum PoliticaRecebimentoMensagens;
Padronização da política de recebimento de mensagens no modelo Usuário;
Criação do caso de teste, que visa cobrir a alteração da política de recebimentos de mensagens.